### PR TITLE
fix: Error from `triggerSignalActivity` when using triggerURL from `getWorkflow`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
   "globals": {
     "fixtureFile": true,
     "fixtureJson": true,
-    "fakeFileSystem": true
+    "fakeFileSystem": true,
+    "fetch": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
+    "node-fetch": "^2.6.0",
     "swagger-client": "^3.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^24.8.0",
+    "jest-fetch-mock": "^2.1.2",
     "jest-junit": "^7.0.0",
     "jest-plugin-fs": "^2.9.0",
     "jsdoc": "^3.6.3",

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -14,6 +14,9 @@ const { stdout } = require('stdout-stderr')
 const fs = require.requireActual('fs')
 const eol = require('eol')
 
+const fetch = require('jest-fetch-mock')
+jest.setMock('node-fetch', fetch)
+
 jest.setTimeout(30000)
 jest.useFakeTimers()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closes #11

## Motivation and Context

The documentation for Campaign Standard specified a relative Trigger URL, which is incorrect (the URL is absolute). The docs have been updated, so the implementation needs to be updated.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
