### PR TITLE
fix: getGDPRDataFile method implementation due to doc change, url is absolute not relative

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -355,18 +355,17 @@ class CampaignStandardCoreAPI {
   /**
    * Get the GDPR data file.
    *
-   * @param {string} privateRequestDataUrl this is acquired from a getGDPRRequest call
+   * @param {string} privacyRequestDataUrl this is acquired from a getGDPRRequest call
+   * @param {string} requestInternalName  the request internal name
+   *
    * @see getGDPRRequest
    */
-  getGDPRDataFile (privateRequestDataUrl) {
+  getGDPRDataFile (privacyRequestDataUrl, requestInternalName) {
     return new Promise((resolve, reject) => {
-      this.sdk.apis.gdpr.getGDPRDataFile({ PRIVACY_REQUEST_DATA_URL: privateRequestDataUrl }, this.__createRequestOptions())
-        .then(response => {
-          resolve(response)
-        })
-        .catch(err => {
-          reject(wrapGeneralError('getGDPRDataFile', err))
-        })
+      this.postDataToUrl(privacyRequestDataUrl, { name: requestInternalName })
+        .then(res => res.json())
+        .then(json => resolve(json))
+        .catch(err => reject(wrapGeneralError('getGDPRDataFile', err)))
     })
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -331,19 +331,40 @@ test('getGDPRRequest', async () => {
   })
 })
 
-test('getGDPRDataFile', async () => {
-  const privateRequestDataUrl = 'https://fake.site'
+test('getGDPRDataFile - success', async () => {
+  const privacyDataRequestUrl = 'https://fake.site'
+  const requestInternalName = 'my-name'
 
-  const sdkArgs = [privateRequestDataUrl]
-  const apiParameters = { PRIVACY_REQUEST_DATA_URL: privateRequestDataUrl }
-  const apiOptions = createSwaggerOptions()
+  const expectedResult = { data: '12345' }
+  fetch.mockResponseOnce(JSON.stringify(expectedResult))
 
-  return standardTest({
-    fullyQualifiedApiName: 'gdpr.getGDPRDataFile',
-    apiParameters,
-    apiOptions,
-    sdkArgs
-  })
+  // this API function does not go through Swagger Client at all,
+  // and goes through node-fetch
+  const client = await createSdkClient()
+  const triggerSuccess = client.getGDPRDataFile(privacyDataRequestUrl, requestInternalName)
+
+  expect(fetch.mock.calls.length).toEqual(1)
+  // [0][0] -> [call-index][argument-index], so first call's first argument
+  expect(fetch.mock.calls[0][0]).toEqual(privacyDataRequestUrl)
+  return expect(triggerSuccess).resolves.toEqual(expectedResult)
+})
+
+test('getGDPRDataFile - error', async () => {
+  const privacyDataRequestUrl = 'https://fake.site'
+  const requestInternalName = 'my-name'
+
+  const expectedError = new Error('Foo')
+  fetch.mockRejectOnce(expectedError)
+
+  // this API function does not go through Swagger Client at all,
+  // and goes through node-fetch
+  const client = await createSdkClient()
+
+  const triggerFail = client.getGDPRDataFile(privacyDataRequestUrl, requestInternalName)
+  expect(fetch.mock.calls.length).toEqual(1)
+  // [0][0] -> [call-index][argument-index], so first call's first argument
+  expect(fetch.mock.calls[0][0]).toEqual(privacyDataRequestUrl)
+  return expect(triggerFail).rejects.toEqual(new Error(`Error while calling Adobe Campaign Standard getGDPRDataFile - ${expectedError}`))
 })
 
 test('sendTransactionalEvent', async () => {


### PR DESCRIPTION
## Description

Closes #13 

## Motivation and Context

Due to a Campaign Standard doc change, the privacy data request URL is supposed to be absolute, not relative. The implementation for getGdprDataFile is changed to reflect this.

## How Has This Been Tested?

npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
